### PR TITLE
Feat: 공개 일기 조회 API 구현

### DIFF
--- a/controllers/diary.controller.js
+++ b/controllers/diary.controller.js
@@ -1,0 +1,63 @@
+const mongoose = require("mongoose");
+require("../models/User");
+const Diary = require("../models/Diary");
+
+const PAGE_SIZE = 9; // 상의 후 변경
+
+const diaryController = {};
+
+// 전체 일기들 가져오기 (Read)
+diaryController.getAllDiaries = async (req, res) => {
+  try {
+    const { lastId } = req.query;
+    const filter = { isPublic: true };
+
+    const raw = typeof lastId === "string" ? lastId.trim() : lastId;
+    if (raw) {
+      if (!mongoose.isValidObjectId(raw)) {
+        return res
+          .status(400)
+          .json({ status: "fail", message: "Invalid lastId" });
+      }
+      filter._id = { $lt: mongoose.Types.ObjectId.createFromHexString(raw) };
+    }
+
+    const items = await Diary.find(filter)
+      .select("title content createdAt userId") // 필요한 필드만 가져오기
+      .sort({ _id: -1 })
+      .limit(PAGE_SIZE + 1)
+      .populate({ path: "userId", select: "name profile -_id" })
+      .lean({ virtuals: true });
+
+    const hasNextPage = items.length > PAGE_SIZE;
+    const sliced = hasNextPage ? items.slice(0, PAGE_SIZE) : items;
+    const nextLastId = hasNextPage
+      ? String(sliced[sliced.length - 1]._id)
+      : null;
+
+    const diaries = sliced.map((d) => ({
+      _id: d._id,
+      title: d.title,
+      content: d.content,
+      createdAt: d.createdAt,
+      author: {
+        name: d.userId?.name ?? null,
+        profile: d.userId?.profile ?? null,
+      },
+    }));
+
+    res.status(200).json({
+      status: "success",
+      pageSize: PAGE_SIZE,
+      isFirstPage: !raw,
+      hasNextPage,
+      nextLastId,
+      count: diaries.length,
+      diaries,
+    });
+  } catch (error) {
+    res.status(500).json({ status: "fail", message: error.message });
+  }
+};
+
+module.exports = diaryController;

--- a/models/Diary.js
+++ b/models/Diary.js
@@ -22,5 +22,11 @@ const diarySchema = new Schema(
   { timestamps: true }
 );
 
+// 공개 피드 최신순 무한 스크롤
+diarySchema.index({ isPublic: 1, _id: -1 });
+
+// 사용자별 특정 날짜 (하루 한 편 정책)
+diarySchema.index({ userId: 1, date: 1 }, { unique: true });
+
 const Diary = mongoose.model("Diary", diarySchema);
 module.exports = Diary;

--- a/models/User.js
+++ b/models/User.js
@@ -30,8 +30,6 @@ const userSchema = new Schema(
       trim: true, // 문자열 앞뒤 공백 제거 후 저장
       set: (v) => (typeof v === "string" && v.trim() ? v.trim() : null), // 빈 문자열이 들어오는 실수를 방지: 빈 값이면 null로 정규화
     },
-    // 권장: 저장하지 말고 virtual populate 사용 (아래 주석 참고)
-    diaryIds: [{ type: Schema.Types.ObjectId, ref: "Diary" }],
   },
   {
     timestamps: true,
@@ -55,13 +53,13 @@ const userSchema = new Schema(
   }
 );
 
-// 권장: User에는 배열 저장 X, Diary.author로 역참조
-// userSchema.virtual("diaries", {
-//   ref: "Diary",
-//   localField: "_id",
-//   foreignField: "author",
-//   options: { sort: { createdAt: -1 } },
-// });
+// User에는 배열 저장 X, Diary.userId로 역참조
+userSchema.virtual("diaries", {
+  ref: "Diary",
+  localField: "_id",
+  foreignField: "userId",
+  options: { sort: { createdAt: -1 } },
+});
 
 const User = mongoose.model("User", userSchema);
 module.exports = User;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "nodemon app.js"
+    "start": "nodemon app.js",
+    "seed": "node seed/seedforReadDiaries.js"
   },
   "keywords": [],
   "author": "",

--- a/routes/diary.api.js
+++ b/routes/diary.api.js
@@ -1,0 +1,7 @@
+const express = require("express");
+const diaryController = require("../controllers/diary.controller");
+const router = express.Router();
+
+router.get("/", diaryController.getAllDiaries);
+
+module.exports = router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,4 +1,7 @@
 const express = require("express");
 const router = express.Router();
+const diaryApi = require("./diary.api");
+
+router.use("/diary", diaryApi);
 
 module.exports = router;

--- a/seed/seedforReadDiaries.js
+++ b/seed/seedforReadDiaries.js
@@ -1,0 +1,130 @@
+const mongoose = require("mongoose");
+require("dotenv").config();
+
+const User = require("../models/User");
+const Diary = require("../models/Diary");
+
+const MONGODB_URI = process.env.MONGODB_URI_PROD;
+
+const seed = async () => {
+  try {
+    await mongoose.connect(MONGODB_URI);
+    console.log("✅ DB connected");
+
+    // 기존 데이터 삭제
+    await User.deleteMany({});
+    await Diary.deleteMany({});
+    console.log("기존 User/Diary 데이터 삭제 완료");
+
+    // 1. User 시드 데이터 생성 및 삽입
+    const users = await User.insertMany([
+      {
+        email: "alice@example.com",
+        password: "hashedpassword1", // 실제 운영에선 bcrypt로 해싱된 값 필요
+        name: "Alice",
+        profile: "/images/default.png",
+      },
+      {
+        email: "bob@example.com",
+        password: "hashedpassword2",
+        name: "Bob",
+        profile: "/images/default.png",
+      },
+    ]);
+    console.log("User 시드 데이터 삽입 완료");
+
+    // 2. Diary 시드 데이터 생성
+    const diaries = [
+      {
+        userId: users[0]._id, // Alice
+        title: "Alice's First Diary",
+        content: "Today I started writing my English diary!",
+        isPublic: true,
+        date: new Date("2025-08-20"),
+      },
+      {
+        userId: users[0]._id,
+        title: "Alice's Second Diary",
+        content: "Studied vocabulary for 2 hours.",
+        isPublic: false,
+        date: new Date("2025-08-21"),
+      },
+      {
+        userId: users[1]._id, // Bob
+        title: "Bob's Diary",
+        content: "Went hiking and wrote about it in English.",
+        isPublic: true,
+        date: new Date("2025-08-22"),
+      },
+      {
+        userId: users[0]._id,
+        title: "Alice – Morning Routine",
+        content: "I practiced English speaking for 20 minutes this morning.",
+        isPublic: true,
+        date: new Date("2025-08-23"),
+      },
+      {
+        userId: users[1]._id,
+        title: "Bob – Coffee Chat",
+        content: "Chatted with a friend about travel plans in English.",
+        isPublic: true,
+        date: new Date("2025-08-24"),
+      },
+      {
+        userId: users[0]._id,
+        title: "Alice – Reading Time",
+        content: "Read an English article about technology.",
+        isPublic: true,
+        date: new Date("2025-08-25"),
+      },
+      {
+        userId: users[1]._id,
+        title: "Bob – Gym Notes",
+        content: "Described my workout routine in English.",
+        isPublic: true,
+        date: new Date("2025-08-26"),
+      },
+      {
+        userId: users[0]._id,
+        title: "Alice – Movie Review",
+        content: "Wrote a short review of an English movie.",
+        isPublic: true,
+        date: new Date("2025-08-27"),
+      },
+
+      {
+        userId: users[1]._id,
+        title: "Bob – Private Thoughts",
+        content: "Reflected on my study progress.",
+        isPublic: false,
+        date: new Date("2025-08-28"),
+      },
+      {
+        userId: users[0]._id,
+        title: "Alice – Vocabulary List",
+        content: "Compiled new words learned today.",
+        isPublic: false,
+        date: new Date("2025-08-29"),
+      },
+      {
+        userId: users[1]._id,
+        title: "Bob – Late Night Study",
+        content: "Practiced grammar quietly at night.",
+        isPublic: false,
+        date: new Date("2025-08-30"),
+      },
+    ];
+
+    await Diary.insertMany(diaries);
+    console.log("Diary 시드 데이터 삽입 완료");
+  } catch (error) {
+    console.error(error);
+    process.exitCode = 1;
+  } finally {
+    await mongoose.disconnect();
+    console.log("🔌 DB disconnected");
+    process.exit();
+  }
+};
+
+seed();


### PR DESCRIPTION
## 개요

공개 일기 조회 API 구현 (무한 스크롤 기준)

## 변경 사항

- [x]  새로운 기능 추가
- [ ]  버그 수정
- [x]  리팩토링
- [ ]  문서 수정

## 구현 내용

- User 스키마에서 diaryIds 제거 및 virtual populate로 변경
- Diary 스키마에 인덱스 추가 (공개 피드 최신순, 사용자별 하루 한 편 제한)
- User와 Diary 시드 데이터 스크립트 추가 (`seedforReadDiaries.js` 파일 생성)
- `package.json` 파일에 seed 스크립트 추가 (`seedforReadDiaries.js` 파일 실행용)

## 개발 후기 및 개선사항

### 이번 작업에서 배운 점

- Diary 스키마에 추가한 두 인덱스 각각의 역할
    - 공개 피드 최신순 무한 스크롤
        
        ```jsx
        diarySchema.index({ isPublic: 1, _id: 1 });
        ```
        
        - 용도: `find({ isPublic: true, _id: { $lt: ... } }).sort({ _id: -1 })`
        - **전체 공개 일기 피드**를 **최신순**으로 불러오는 쿼리 최적화
    - 사용자별 특정 날짜 (하루 한 편 정책)
        
        ```jsx
        diarySchema.index({ userId: 1, date: 1 }, { unique: true });
        ```
        
        - 용도: `findOne({ userId, date })`
        - **마이페이지에서 특정 날짜의 일기 조회** 최적화
        - `{ unique: true }` 옵션은 한 유저가 같은 날짜에 일기를 두 번 쓰지 못하게 하는 **데이터 무결성 보장**까지 담당

### 어려웠던 점 / 에로사항

- (없다면 패스)

### 다음에 개선하고 싶은 점

- 실제 데이터로 API 요청해보기

### 팀원들과 공유하고 싶은 팁

- 시드(seed) 데이터는 **DB에 초기 더미 데이터를 넣어주는 스크립트**로, 보통 백엔드 프로젝트 폴더에 전용 파일을 하나 만들어서 실행해요. 그래서 저도 `seed`라는 폴더를 새로 만들어서, 그 아래에 시드 스크립트(`seedforReadDiaries.js`)를 넣어 주었습니다!


- 시드 실행은 서버 실행이랑 별개여서, `package.json`에 seed 스크립트를 따로 등록해 두었습니다.
    - `npm start` → `nodemon app.js` 실행 → **Express 서버를 띄우는 용도**
    - 시드(seed) 스크립트 → **DB에 초기 데이터만 넣고 종료하는 용도** → 서버처럼 계속 켜져 있으면 안 되고, 실행 후 바로 끝나야 함
    - 다음과 같이 실행하면 됩니다.    
        ```bash
        npm run seed   # 시드 데이터 넣기
        npm start      # 서버 실행하기
        ```
   