### PR TITLE
Feat: 일기 교정 및 생성

### DIFF
--- a/controllers/diary.controller.js
+++ b/controllers/diary.controller.js
@@ -1,10 +1,64 @@
 const mongoose = require("mongoose");
 require("../models/User");
 const Diary = require("../models/Diary");
+const { correctDiary, generateDiaryComment } = require("../services/chatGPT");
 
 const PAGE_SIZE = 9; // 상의 후 변경
 
 const diaryController = {};
+
+diaryController.createDiary = async (req, res) => {
+  const { userId, title, content, image, isPublic, date } = req.body || {};
+
+  try {
+    const diaryDate = new Date(date);
+    const today = new Date();
+    today.setHours(0, 0, 0, 0); // 오늘 0시 기준
+    const twoDaysAgo = new Date(today);
+    twoDaysAgo.setDate(today.getDate() - 2);
+
+    if (diaryDate < twoDaysAgo || diaryDate > today) {
+      return res.status(400).json({
+        success: false,
+        message: "작성 가능한 날짜는 오늘 기준 -2일부터 오늘까지 입니다.",
+      });
+    }
+
+    const sentences = content.split(/[\n.?!]+/).filter((s) => s.trim() !== "");
+
+    const corrections = await Promise.all(
+      sentences.map(async (sentence) => {
+        const result = await correctDiary(sentence);
+        return {
+          originalSentence: sentence,
+          correctedSentence: result?.correctedSentence || sentence,
+          reason: result?.reason || "No corrections needed",
+          similarExpressions: result?.similarExpressions || [],
+          extraExamples: result?.extraExamples || [],
+        };
+      })
+    );
+
+    const commentObj = await generateDiaryComment(content);
+    const commentText = commentObj.commentText;
+
+    const diary = new Diary({
+      userId,
+      title,
+      content,
+      image,
+      isPublic,
+      date,
+      corrections,
+      comment: commentText
+    });
+
+    const savedDiary = await diary.save();
+    return res.status(200).json({ status: "success", diary: savedDiary });
+  } catch (error) {
+    return res.status(400).json({ status: "fail", error: error.message });
+  }
+};
 
 // 전체 일기들 가져오기 (Read)
 diaryController.getAllDiaries = async (req, res) => {

--- a/models/Diary.js
+++ b/models/Diary.js
@@ -17,6 +17,7 @@ const diarySchema = new Schema(
     image: { type: String },
     isPublic: { type: Boolean, default: true },
     corrections: [correctionSchema],
+    comment: { type: String, required: true },
     date: { type: Date, required: true },
   },
   { timestamps: true }

--- a/routes/diary.api.js
+++ b/routes/diary.api.js
@@ -2,6 +2,7 @@ const express = require("express");
 const diaryController = require("../controllers/diary.controller");
 const router = express.Router();
 
+router.post("/", diaryController.createDiary);
 router.get("/", diaryController.getAllDiaries);
 
 module.exports = router;

--- a/services/chatGPT.js
+++ b/services/chatGPT.js
@@ -1,9 +1,10 @@
 require("dotenv").config();
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+const apiEndpoint = 'https://api.openai.com/v1/chat/completions';
 
 // 공통 함수: ChatGPT API 호출
 const callChatGPT = async (prompt, temperature = 0.3) => {
-  const response = await fetch("https://api.openai.com/v1/chat/completions", {
+  const response = await fetch(apiEndpoint, {
     method: "POST",
     headers: {
       Authorization: `Bearer ${OPENAI_API_KEY}`,

--- a/services/chatGPT.js
+++ b/services/chatGPT.js
@@ -1,0 +1,80 @@
+require("dotenv").config();
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+
+// 공통 함수: ChatGPT API 호출
+const callChatGPT = async (prompt, temperature = 0.3) => {
+  const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${OPENAI_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "gpt-4o-mini",
+      messages: [
+        {
+          role: "system",
+          content: "You are a helpful assistant that returns JSON only.",
+        },
+        { role: "user", content: prompt },
+      ],
+      temperature,
+    }),
+  });
+
+  const data = await response.json();
+  if (!data.choices || data.choices.length === 0) {
+    console.log(JSON.stringify(data, null, 2));
+    throw new Error("OpenAI API 응답에 choices가 없습니다.");
+  }
+  const text = data.choices[0].message.content;
+
+  try {
+    const jsonStart = text.indexOf("{");
+    const jsonEnd = text.lastIndexOf("}") + 1;
+    const jsonString = text.slice(jsonStart, jsonEnd);
+    return JSON.parse(jsonString);
+  } catch (err) {
+    console.error("JSON parsing error:", err, text);
+    return null;
+  }
+};
+
+// 1. 일기 문장 교정
+const correctDiary = async (originalSentence) => {
+  const prompt = `
+    다음 문장을 현지에서 사용하는 영어 표현으로 교정하고, 이유와 유사 표현, 추가 예문을 JSON 형식으로 제공해줘. 교정 이유는 한국말로 작성해줘.
+    원문: ${originalSentence}
+
+    응답은 JSON 형식으로 줘:
+    {
+    "correctedSentence": "",
+    "reason": "",
+    "similarExpressions": [],
+    "extraExamples": []
+    }`;
+
+  return await callChatGPT(prompt);
+};
+
+// 2. 코멘트 생성
+const generateDiaryComment = async (diaryContent) => {
+  const prompt = `
+    다음 일기를 읽고 감정을 고려한 코멘트를 작성해줘.
+    - 코멘트는 한 문단 정도로 간결하게
+    - JSON 형식으로 반환
+    일기:
+    ${diaryContent}
+
+    응답 형식:
+    {
+    "commentText": ""
+    }`;
+
+  return await callChatGPT(prompt);
+};
+
+module.exports = {
+  correctDiary,
+  generateDiaryComment,
+};

--- a/utils/isValidDiaryDate.js
+++ b/utils/isValidDiaryDate.js
@@ -1,0 +1,12 @@
+function isValidDiaryDate(date) {
+  const diaryDate = new Date(date);
+  const today = new Date();
+  today.setHours(0, 0, 0, 0); // 오늘 0시 기준
+
+  const twoDaysAgo = new Date(today);
+  twoDaysAgo.setDate(today.getDate() - 2);
+
+  return diaryDate >= twoDaysAgo && diaryDate <= today;
+}
+
+module.exports = isValidDiaryDate;


### PR DESCRIPTION
## 개요

이 PR의 목적과 구현 내용을 간단히 설명합니다.

## 변경 사항

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 구현 내용
- 일기 내용을 하나의 문장씩 분리
- 각각의 문장으로 chatGPT를 통해 현지 표현으로 교정, 교정 이유(한국어), 다른 표현, 예시를 받아옴
- 일기 문단을 chatGPT를 통해 감정을 고려한 코멘트(영어)를 받아옴
- 문장 속 에러가 없다면 교정 문장 = 원본 문장, 교정 이유는 "No corrections needed"
- 해당 결과를 받고 일기 저장
- 오늘 기준 -2일 부터 오늘까지만 일기 생성 가능

## 개발 후기 및 개선사항

### 이번 작업에서 배운 점
chatGPT API 연결

### 어려웠던 점 / 에로사항
nodeJS에서 fetch를 하는데 const fetch = require("node-fetch");를 썼는데 계속 에러가 났다.
알고보니 최신 버전에는 fetch가 기본적으로 내장되어 있어서 오히려 저 코드가 에러를 일으킴

### 다음에 개선하고 싶은 점
현재에는 auth가 없어서 userId를 body로 받아오고 있습니다. 나중에 머지하고 변경하겠습니다.

### 팀원들과 공유하고 싶은 팁
chatGPT API 호출하는 공통부분은 callChatGPT으로 만들었습니다.
만약 chatGPT를 쓸 일이 있다면 아래에서 프롬프트만 만들어서 callChatGPT로 프롬프트를 전달하면 됩니다.

.env에 chatGPT API KEY 추가해주세요~~
