### PR TITLE
Feat/diary: 특정 사용자 일기 조회(Read) 컨트롤러 구현

### DIFF
--- a/controllers/diary.controller.js
+++ b/controllers/diary.controller.js
@@ -69,7 +69,7 @@ diaryController.getAllDiaries = async (req, res) => {
     }
 
     const items = await Diary.find(filter)
-      .select("_id title content date createdAt userId") // 필요한 필드만 가져오기
+      .select("_id title content date dateKey createdAt userId") // 필요한 필드만 가져오기
       .sort({ _id: -1 })
       .limit(PAGE_SIZE + 1)
       .populate({ path: "userId", select: "name profile -_id" })

--- a/controllers/diary.controller.js
+++ b/controllers/diary.controller.js
@@ -1,6 +1,7 @@
 const mongoose = require("mongoose");
 require("../models/User");
 const Diary = require("../models/Diary");
+const { kstDateKey, kstDateKeyMinusDays } = require("../utils/time");
 
 const PAGE_SIZE = 9; // 상의 후 변경
 
@@ -23,7 +24,7 @@ diaryController.getAllDiaries = async (req, res) => {
     }
 
     const items = await Diary.find(filter)
-      .select("title content createdAt userId") // 필요한 필드만 가져오기
+      .select("_id title content date createdAt userId") // 필요한 필드만 가져오기
       .sort({ _id: -1 })
       .limit(PAGE_SIZE + 1)
       .populate({ path: "userId", select: "name profile -_id" })
@@ -54,6 +55,103 @@ diaryController.getAllDiaries = async (req, res) => {
       nextLastId,
       count: diaries.length,
       diaries,
+    });
+  } catch (error) {
+    res.status(500).json({ status: "fail", message: error.message });
+  }
+};
+
+// 특정 사용자의 일기들을 월 단위로 가져오기 (Read)
+diaryController.getOneUserDiaries = async (req, res) => {
+  try {
+    const { userId } = req;
+    if (!userId || !mongoose.isValidObjectId(userId)) {
+      return res.status(401).json({ status: "fail", message: "Unauthorized" });
+    }
+
+    // 프론트에서 쿼리에 year, month를 넣어줘야 함
+    const year = Number(req.query.year);
+    const month = Number(req.query.month);
+
+    const validYear = Number.isInteger(year) && year >= 1970 && year <= 2100;
+    const validMonth = Number.isInteger(month) && month >= 1 && month <= 12;
+
+    if (!validYear || !validMonth) {
+      return res.status(400).json({
+        status: "fail",
+        message: "Invalid year or month",
+      });
+    }
+
+    const yearAndMonth = `${year}-${String(month).padStart(2, "0")}`;
+    const nextYearAndMonth =
+      month === 12
+        ? `${year + 1}-01`
+        : `${year}-${String(month + 1).padStart(2, "0")}`;
+    const startKey = `${yearAndMonth}-01`;
+    const endKey = `${nextYearAndMonth}-01`;
+
+    // DB에서 특정 달의 특정 사용자의 일기만 추출
+    const rows = await Diary.find({
+      userId,
+      dateKey: { $gte: startKey, $lt: endKey }, // startKey 이상 endKey 미만
+    })
+      .select("_id dateKey")
+      .lean();
+
+    // 빠른 조회를 위한 맵 구성
+    // Map의 키: dateKey(YYYY-MM-DD), 값: _id
+    const map = new Map(rows.map((r) => [r.dateKey, String(r._id)]));
+
+    // 달의 모든 날짜 만들기
+    const daysInMonth = new Date(year, month, 0).getDate(); // 해당 달의 총 일수
+    const today = kstDateKey(); // 오늘
+    const yesterday = kstDateKeyMinusDays(1); // 어제
+    const beforeYesterday = kstDateKeyMinusDays(2); // 그제
+
+    // 달력에 뿌릴 days 배열 만들기
+    const days = Array.from({ length: daysInMonth }, (_, i) => {
+      const day = String(i + 1).padStart(2, "0");
+      const dk = `${yearAndMonth}-${day}`;
+      return {
+        date: dk,
+        id: map.get(dk) ?? null,
+        canWrite: dk === today || dk === yesterday || dk === beforeYesterday,
+      };
+    });
+
+    return res.status(200).json({ status: "success", year, month, days });
+  } catch (error) {
+    res.status(500).json({ status: "fail", message: error.message });
+  }
+};
+
+// 특정 사용자의 특정 날짜 일기 가져오기 (Read)
+diaryController.getDiaryByDate = async (req, res) => {
+  try {
+    const { userId } = req;
+    if (!userId || !mongoose.isValidObjectId(userId)) {
+      return res.status(401).json({ status: "fail", message: "Unauthorized" });
+    }
+
+    const { date } = req.query; // 프론트에서 쿼리에 "YYYY-MM-DD" 형식으로 날짜를 줘야 함
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      return res
+        .status(400)
+        .json({ status: "fail", message: "Invalid date format" });
+    }
+
+    const doc = await Diary.findOne({ userId, dateKey: date })
+      .select(
+        "_id title content image isPublic date dateKey createdAt updatedAt"
+      )
+      .lean();
+
+    // doc가 있으면 상세 모달/페이지로 보여주고, 없으면 "새 일기 작성" UI로 전환함
+    return res.status(200).json({
+      status: "success",
+      found: !!doc,
+      diary: doc ?? null,
     });
   } catch (error) {
     res.status(500).json({ status: "fail", message: error.message });

--- a/models/Diary.js
+++ b/models/Diary.js
@@ -1,5 +1,6 @@
 const mongoose = require("mongoose");
 const Schema = mongoose.Schema;
+const { format, utcToZonedTime } = require("date-fns-tz");
 
 const correctionSchema = new Schema({
   originalSentence: { type: String, required: true },
@@ -17,16 +18,45 @@ const diarySchema = new Schema(
     image: { type: String },
     isPublic: { type: Boolean, default: true },
     corrections: [correctionSchema],
-    date: { type: Date, required: true },
+    // 원본 시간 (UTC 타임스탬프 - 정렬/집계/범위용)
+    date: { type: Date, required: true, immutable: true },
+    // "YYYY-MM-DD" (현지 날짜(KST) - 달력/인덱스 정책용 현지 날짜 문자열)
+    dateKey: {
+      type: String,
+      required: true,
+      immutable: true, // 생성 후 변경 불가
+      match: /^\d{4}-\d{2}-\d{2}$/,
+    },
   },
   { timestamps: true }
 );
+
+// 미들웨어: 검증(validator)들이 실행되기 직전에 호출
+diarySchema.pre("validate", function (next) {
+  // this: 현재 저장/검증 중인 문서(doc)
+  // 새 문서거나, date 필드가 수정된 경우에 dateKey 재계산
+  if (this.isNew || this.isModified("date")) {
+    const z = "Asia/Seoul";
+    const d = this.date instanceof Date ? this.date : new Date(this.date);
+    if (!(d instanceof Date) || Number.isNaN(d.getTime())) {
+      return next(
+        new mongoose.Error.ValidatorError({
+          path: "date",
+          message: "유효한 날짜를 입력하세요.",
+        })
+      );
+    }
+    const zoned = utcToZonedTime(d, z); // date(UTC) → KST 시각
+    this.dateKey = format(zoned, "yyyy-MM-dd", { timeZone: z });
+  }
+  next();
+});
 
 // 공개 피드 최신순 무한 스크롤
 diarySchema.index({ isPublic: 1, _id: -1 });
 
 // 사용자별 특정 날짜 (하루 한 편 정책)
-diarySchema.index({ userId: 1, date: 1 }, { unique: true });
+diarySchema.index({ userId: 1, dateKey: 1 }, { unique: true });
 
 const Diary = mongoose.model("Diary", diarySchema);
 module.exports = Diary;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "bcryptjs": "^3.0.2",
         "body-parser": "^2.2.0",
         "cors": "^2.8.5",
+        "date-fns": "^4.1.0",
+        "date-fns-tz": "^3.2.0",
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
@@ -271,6 +273,25 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+      "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "date-fns": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "bcryptjs": "^3.0.2",
     "body-parser": "^2.2.0",
     "cors": "^2.8.5",
+    "date-fns": "^4.1.0",
+    "date-fns-tz": "^3.2.0",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",

--- a/routes/diary.api.js
+++ b/routes/diary.api.js
@@ -1,7 +1,18 @@
 const express = require("express");
 const diaryController = require("../controllers/diary.controller");
+const authController = require("../controllers/auth.controller");
 const router = express.Router();
 
 router.get("/", diaryController.getAllDiaries);
+router.get(
+  "/my",
+  authController.authenticate,
+  diaryController.getOneUserDiaries
+);
+router.get(
+  "/my/date",
+  authController.authenticate,
+  diaryController.getDiaryByDate
+);
 
 module.exports = router;

--- a/utils/time.js
+++ b/utils/time.js
@@ -11,7 +11,7 @@ function kstDateKey(date = new Date()) {
 // 오늘로부터 n일 전의 날짜를 KST 기준 "YYYY-MM-DD" 문자열로 변환
 function kstDateKeyMinusDays(days) {
   const ms = days * 24 * 60 * 60 * 1000;
-  return kstDateKey(newDate(Date.now() - ms));
+  return kstDateKey(new Date(Date.now() - ms));
 }
 
 module.exports = { kstDateKey, kstDateKeyMinusDays, ZONE };

--- a/utils/time.js
+++ b/utils/time.js
@@ -9,8 +9,8 @@ function kstDateKey(date = new Date()) {
 }
 
 // 오늘로부터 n일 전의 날짜를 KST 기준 "YYYY-MM-DD" 문자열로 변환
-function kstDateKeyMinusDays(days) {
-  const ms = days * 24 * 60 * 60 * 1000;
+function kstDateKeyMinusDays(n) {
+  const ms = n * 24 * 60 * 60 * 1000;
   return kstDateKey(new Date(Date.now() - ms));
 }
 

--- a/utils/time.js
+++ b/utils/time.js
@@ -1,0 +1,17 @@
+const { utcToZonedTime, format } = require("date-fns-tz");
+
+const ZONE = "Asia/Seoul";
+
+// 주어진 Date(지금)를 KST(Asia/Seoul) 기준 "YYYY-MM-DD" 문자열로 변환
+function kstDateKey(date = new Date()) {
+  const zoned = utcToZonedTime(date, ZONE);
+  return format(zoned, "yyyy-MM-dd", { timeZone: ZONE });
+}
+
+// 오늘로부터 n일 전의 날짜를 KST 기준 "YYYY-MM-DD" 문자열로 변환
+function kstDateKeyMinusDays(days) {
+  const ms = days * 24 * 60 * 60 * 1000;
+  return kstDateKey(newDate(Date.now() - ms));
+}
+
+module.exports = { kstDateKey, kstDateKeyMinusDays, ZONE };


### PR DESCRIPTION
## 개요

특정 사용자의 일기들을 월 단위로 가져오는(GET) 컨트롤러와, 특정 사용자의 특정 날짜 일기를 가져오는(GET) 컨트롤러 구현

## 변경 사항

- [x]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  리팩토링
- [ ]  문서 수정

## 구현 내용

- **`time.js` : KST 날짜 유틸 추가**
    - `kstDateKey(date?)` : Asia/Seoul 기준 'yyyy-MM-dd' 반환
    - `kstDateKeyMinusDays(n)` : 오늘로부터 n일 전 KST 날짜키 반환
    - ZONE 상수 노출
- **`diary.controller.js` : 월/일 조회를 dateKey 기준으로 수정 및 검증 강화**
    - `getOneUserDiaries`
        - dateKey 범위(startKey <= dateKey < endKey)로 조회
        - year/month 유효성 강화(1970–2100, 1–12)
    - `getAllDiaries`
        - projection에 _id, date, dateKey 포함하여 페이징/정렬 안정성 확보
    - 달력 날짜 (days)
        - today/yesterday/beforeYesterday를 KST 유틸로 계산하여 canWrite 정확도 개선
- **`Diary.js` : dateKey 도입 및 하루 1편 정책 강화**
    - `dateKey`(yyyy-MM-dd, KST) 필드 추가 및 `immutable` 처리
    - pre('validate'): date → dateKey 자동 계산(utcToZonedTime/format) + 유효한 날짜 가드
    - 인덱스 변경: `{ userId, date }` → `{ userId, dateKey }` (unique)
    - `date` 필드 `immutable` 지정
    - date-fns-tz 의존으로 타임존 안전성 확보
- **`diary.api.js` : 특정 사용자의 일기 조회 라우트 추가 및 인증 연동**
    - `authController.authenticate` 미들웨어 연결
    - GET /diary/my: 로그인 사용자 월별 일기 조회
    - GET /diary/my/date: 로그인 사용자 특정 날짜 일기 조회

## 개발 후기 및 개선사항

### 이번 작업에서 배운 점

- MongoDB 비교 연산자: `$gte`, `$lt`
  - **`$gte`**
    - Greater Than or Equal → **이상(≥)**
    - 해당 필드 값이 **기준값 이상**인 문서만 매칭함
  - **`$lt`**
    - Less Than → **미만(<)**
    - 해당 필드 값이 **기준값 미만**인 문서만 매칭함
  - 우리 코드에서는?
    ```js
    const rows = await Diary.find({
      userId,
      dateKey: { $gte: startKey, $lt: endKey },
    })
    ```
    ➡️ `dateKey`가 **`startKey` 이상**이고 **`endKey` 미만**인 문서, 즉 **[startKey, endKey)** 구간에 속하는 문서들을 찾음
      > **왜 [startKey, endKey) (끝 미만)로 할까?**
      >
      > 경계에서 **중복/누락을 막기 위해서**이다.
      > 예를 들어, 8월과 9월을 연달아 조회할 때, **8월 끝 = 9월 시작**이 같은 시각이므로,
      > 8월은 `< 9월 시작`, 9월은 `≥ 9월 시작`으로 나누면 겹치지 않는다.

- `pre("validate")` 훅
  - **`pre("validate")` 훅이란?**
    - **Mongoose 문서 미들웨어** 중 하나로, **검증(validator)들이 실행되기 직전**에 호출됨
    - 이 훅에서는 **`this`** 가 **현재 저장/검증 중인 문서(doc)** 를 가리킴 → 그래서 `this.date`에 접근 가능
  - **왜 validate 이전일까?**
    - 스키마에서 `dateKey`를 `required: true`로 뒀으므로, **검증 전에 `dateKey`를 자동으로 채워 넣어야 검증에 통과**함
    - 만약 **`pre("save")`에서 채우면 검증이 먼저 실행**되므로, `required`에 걸려 실패할 수 있음

### 어려웠던 점 / 에로사항

- 특정 사용자가 보고 있는 달의 일기 목록을 조회할 때 고려 요소가 많아, 로직 설계가 까다로웠다.

### 다음에 개선하고 싶은 점

- (없다면 패스)

### 팀원들과 공유하고 싶은 팁

- `date`(타입: `Date`) 필드와 `dateKey`(타입: `String`) 필드를 함께 저장하는 이유
  - `date`를 유지하는 이유
    - `Date` 타입은 **정렬/범위 쿼리**가 정확하고 빠름 (인덱스 최적화)
    - 나중에 **작성 시간**까지 UI에 보여주거나, **시간 단위 기능(정렬, 통계 등)** 이 생긴다고 했을 때 확장성이 좋음
    - MongoDB의 날짜 연산/집계(aggregation) 연산자들을 쓸 수 있음
  - `dateKey`를 같이 두면 좋은 이유
    - **달력은 현지 날짜(KST) 기준이 필수**
      - 시간대 때문에 `Date`만으로 월/일 조회가 미묘하게 흔들릴 수 있음
      - **`dateKey: 'YYYY-MM-DD'`**(KST 기준)으로 설정하면 쿼리가 매우 직관적이고 안전함
    - **하루 한 편 정책**을 **유니크 인덱스**로 강제하기 좋음
      ```js
      diarySchema.index({ userId: 1, dateKey: 1 }, { unique: true });
      ```
    - 월 조회도 간단하게 할 수 있음
      ```js
      // "2025-08" 한 달
      Diary.find({ userId, dateKey: { $gte: "2025-08-01", $lt: "2025-09-01" } });
      // 실제 코드에서는 변수를 사용함
      ```