### PR TITLE
Refactor/diary: 에러 로직, 컨트롤러 함수명 리팩토링

### DIFF
--- a/controllers/diary.controller.js
+++ b/controllers/diary.controller.js
@@ -61,9 +61,7 @@ diaryController.getAllDiaries = async (req, res) => {
     const raw = typeof lastId === "string" ? lastId.trim() : lastId;
     if (raw) {
       if (!mongoose.isValidObjectId(raw)) {
-        return res
-          .status(400)
-          .json({ status: "fail", message: "Invalid lastId" });
+        throw new Error("유효한 lastId가 아닙니다.");
       }
       filter._id = { $lt: mongoose.Types.ObjectId.createFromHexString(raw) };
     }
@@ -102,16 +100,16 @@ diaryController.getAllDiaries = async (req, res) => {
       diaries,
     });
   } catch (error) {
-    res.status(500).json({ status: "fail", message: error.message });
+    res.status(400).json({ status: "fail", message: error.message });
   }
 };
 
 // 특정 사용자의 일기들을 월 단위로 가져오기 (Read)
-diaryController.getOneUserDiaries = async (req, res) => {
+diaryController.getUserDiariesByMonth = async (req, res) => {
   try {
     const { userId } = req;
     if (!userId || !mongoose.isValidObjectId(userId)) {
-      return res.status(401).json({ status: "fail", message: "Unauthorized" });
+      throw new Error("권한이 없습니다.");
     }
 
     // 프론트에서 쿼리에 year, month를 넣어줘야 함
@@ -121,12 +119,8 @@ diaryController.getOneUserDiaries = async (req, res) => {
     const validYear = Number.isInteger(year) && year >= 1970 && year <= 2100;
     const validMonth = Number.isInteger(month) && month >= 1 && month <= 12;
 
-    if (!validYear || !validMonth) {
-      return res.status(400).json({
-        status: "fail",
-        message: "Invalid year or month",
-      });
-    }
+    if (!validYear || !validMonth)
+      throw new Error("유효한 연도 또는 날짜가 아닙니다.");
 
     const yearAndMonth = `${year}-${String(month).padStart(2, "0")}`;
     const nextYearAndMonth =
@@ -167,23 +161,23 @@ diaryController.getOneUserDiaries = async (req, res) => {
 
     return res.status(200).json({ status: "success", year, month, days });
   } catch (error) {
-    res.status(500).json({ status: "fail", message: error.message });
+    res.status(400).json({ status: "fail", message: error.message });
   }
 };
 
 // 특정 사용자의 특정 날짜 일기 가져오기 (Read)
-diaryController.getDiaryByDate = async (req, res) => {
+diaryController.getUserDiaryByDate = async (req, res) => {
   try {
     const { userId } = req;
     if (!userId || !mongoose.isValidObjectId(userId)) {
-      return res.status(401).json({ status: "fail", message: "Unauthorized" });
+      throw new Error("권한이 없습니다.");
     }
 
     const { date } = req.query; // 프론트에서 쿼리에 "YYYY-MM-DD" 형식으로 날짜를 줘야 함
     if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
-      return res
-        .status(400)
-        .json({ status: "fail", message: "Invalid date format" });
+      throw new Error(
+        "유효한 날짜 형식이 아닙니다. 'YYYY-MM-DD' 형식으로 입력해 주세요."
+      );
     }
 
     const doc = await Diary.findOne({ userId, dateKey: date })
@@ -199,7 +193,7 @@ diaryController.getDiaryByDate = async (req, res) => {
       diary: doc ?? null,
     });
   } catch (error) {
-    res.status(500).json({ status: "fail", message: error.message });
+    res.status(400).json({ status: "fail", message: error.message });
   }
 };
 

--- a/routes/diary.api.js
+++ b/routes/diary.api.js
@@ -8,12 +8,12 @@ router.get("/", diaryController.getAllDiaries);
 router.get(
   "/my",
   authController.authenticate,
-  diaryController.getOneUserDiaries
+  diaryController.getUserDiariesByMonth
 );
 router.get(
   "/my/date",
   authController.authenticate,
-  diaryController.getDiaryByDate
+  diaryController.getUserDiaryByDate
 );
 
 module.exports = router;

--- a/routes/diary.api.js
+++ b/routes/diary.api.js
@@ -6,7 +6,7 @@ const router = express.Router();
 router.post("/", authController.authenticate, diaryController.createDiary);
 router.get("/", diaryController.getAllDiaries);
 router.get(
-  "/my",
+  "/my/month",
   authController.authenticate,
   diaryController.getUserDiariesByMonth
 );

--- a/utils/isValidDiaryDate.js
+++ b/utils/isValidDiaryDate.js
@@ -1,12 +1,27 @@
+// function isValidDiaryDate(date) {
+//   const diaryDate = new Date(date);
+//   const today = new Date();
+//   today.setHours(0, 0, 0, 0); // 오늘 0시 기준
+
+//   const twoDaysAgo = new Date(today);
+//   twoDaysAgo.setDate(today.getDate() - 2);
+
+//   return diaryDate >= twoDaysAgo && diaryDate <= today;
+// }
+
+// module.exports = isValidDiaryDate;
+
+const { toKstYmd, addDaysFromKstYmd } = require("./kst-utils");
+
 function isValidDiaryDate(date) {
-  const diaryDate = new Date(date);
-  const today = new Date();
-  today.setHours(0, 0, 0, 0); // 오늘 0시 기준
+  const d = new Date(date);
+  if (Number.isNaN(d.getTime())) return false;
 
-  const twoDaysAgo = new Date(today);
-  twoDaysAgo.setDate(today.getDate() - 2);
+  const ymd = toKstYmd(d);
+  const todayYmd = toKstYmd(new Date());
+  const twoDaysAgoYmd = addDaysFromKstYmd(todayYmd, -2);
 
-  return diaryDate >= twoDaysAgo && diaryDate <= today;
+  return ymd >= twoDaysAgoYmd && ymd <= todayYmd;
 }
 
 module.exports = isValidDiaryDate;

--- a/utils/kst-utils.js
+++ b/utils/kst-utils.js
@@ -1,0 +1,20 @@
+const KST_OFFSET = 9 * 60 * 60 * 1000; // 9시간(밀리초) (KST는 UTC+9)
+
+// 날짜 객체 → KST 날짜 문자열("YYYY-MM-DD")
+const toKstYmd = (date) => {
+  const kst = new Date(date.getTime() + KST_OFFSET);
+  const year = kst.getUTCFullYear();
+  const month = String(kst.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(kst.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+// KST 날짜 문자열 n일 이동
+const addDaysFromKstYmd = (ymd, n) => {
+  const [year, month, day] = ymd.split("-").map(Number);
+  const utcAtKstMidnight = Date.UTC(year, month - 1, day) - KST_OFFSET;
+  const shifted = new Date(utcAtKstMidnight + n * 86400000);
+  return toKstYmd(shifted);
+};
+
+module.exports = { toKstYmd, addDaysFromKstYmd };

--- a/utils/time.js
+++ b/utils/time.js
@@ -1,4 +1,6 @@
-const { utcToZonedTime, format } = require("date-fns-tz");
+const dateFnsTz = require("date-fns-tz");
+const utcToZonedTime = dateFnsTz.utcToZonedTime;
+const format = dateFnsTz.format;
 
 const ZONE = "Asia/Seoul";
 


### PR DESCRIPTION
## 개요

에러 로직, 컨트롤러 함수명 리팩토링 및 날짜 검증/비교 로직 개선

## 변경 사항

- [x]  새로운 기능 추가
- [ ]  버그 수정
- [x]  리팩토링
- [ ]  문서 수정

## 구현 내용

- **컨트롤러 함수명 직관적으로 변경**
    - `getOneUserDiaries` → `getUserDiariesByMonth`
    - `getDiaryByDate` → `getUserDiaryByDate`
    - 네이밍을 User 중심으로 통일하여 가독성 개선
- **`diary.controller.js` : 컨트롤러 에러 처리**
    - 개별 `res.status().json()` 대신 `throw new Error()`로 일관성 있는 에러 처리 적용
    - 에러 응답 코드 500 → 400 으로 조정 (클라이언트 요청 검증 실패에 맞게 변경)
- **`Diary.js` : Diary 스키마에서 `date-fns-tz` 제거 후 KST 유틸 적용**
    - `date-fns-tz`(`utcToZonedTime`/`format`) 의존성 제거
    - Date → “YYYY-MM-DD”(KST) 변환을 위한 `toKstYmd` 유틸 사용
    - `pre("validate")` 미들웨어 로직을 순수 JS 처리로 단순화
    - 불필요한 타임존 상수 및 로직 제거
- **`kst-utils.js` : KST 기준 날짜 유틸 추가 (`toKstYmd`, `addDaysFromKstYmd`)**
    - `toKstYmd` : Date 객체를 “YYYY-MM-DD”(KST) 문자열로 변환
    - `addDaysFromKstYmd` : KST 날짜 문자열 기준으로 n일 이동
    - 타임존 의존성을 제거하고 KST 기준으로 날짜 비교/계산 가능하도록 개선
- **`isValidDiaryDate.js` : `isValidDiaryDate` 함수를 KST 기준 날짜 비교 방식으로 수정**
    - 로컬 타임존/시간 단위 비교 제거
    - KST 기준 “YYYY-MM-DD” 문자열 비교로 변경
    - `toKstYmd`, `addDaysFromKstYmd` 유틸 적용해 환경과 무관하게 안정적인 검증 보장
- **`time.js` : time 유틸에서 `date-fns-tz` import 방식 변경**
    - 구조 분해 할당 방식에서 전체 모듈 require 후 속성 할당으로 수정
    - `utcToZonedTime`, `format` 접근 방식을 명확하게 개선
- **`diary.api.js` : 일기 API 라우트 `/my` → `/my/month` 로 수정**
    - 사용자 월 단위 일기 조회 엔드포인트를 명확하게 변경
    - `/my/date` 라우트와 일관성 확보

## 개발 후기 및 개선사항

### 이번 작업에서 배운 점

- (없다면 패스)

### 어려웠던 점 / 에로사항

- (없다면 패스)

### 다음에 개선하고 싶은 점

- (없다면 패스)

### 팀원들과 공유하고 싶은 팁

- (없다면 패스)