### PR TITLE
Feat/diary: KST 날짜 유틸 함수 정리

### DIFF
--- a/controllers/diary.controller.js
+++ b/controllers/diary.controller.js
@@ -1,7 +1,7 @@
 const mongoose = require("mongoose");
 require("../models/User");
 const Diary = require("../models/Diary");
-const { kstDateKey, kstDateKeyMinusDays } = require("../utils/time");
+const { kstDateKey, kstDateKeyMinusDays } = require("../utils/kst-utils");
 const { correctDiary, generateDiaryComment } = require("../services/chatGPT");
 const isValidDiaryDate = require("../utils/isValidDiaryDate");
 
@@ -85,6 +85,8 @@ diaryController.getAllDiaries = async (req, res) => {
       title: d.title,
       content: d.content,
       createdAt: d.createdAt,
+      dateKey: d.dateKey,
+      date: d.date,
       author: {
         name: d.userId?.name ?? null,
         profile: d.userId?.profile ?? null,

--- a/utils/kst-utils.js
+++ b/utils/kst-utils.js
@@ -9,6 +9,16 @@ const toKstYmd = (date) => {
   return `${year}-${month}-${day}`;
 };
 
+// today 기준 n일 전(양수 n)을 KST 날짜 문자열로
+function kstDateKeyMinusDays(n) {
+  return toKstYmd(new Date(Date.now() - n * 86400000));
+}
+
+// 임의 날짜 → KST YYYY-MM-DD
+function kstDateKey(date = new Date()) {
+  return toKstYmd(date);
+}
+
 // KST 날짜 문자열 n일 이동
 const addDaysFromKstYmd = (ymd, n) => {
   const [year, month, day] = ymd.split("-").map(Number);
@@ -17,4 +27,9 @@ const addDaysFromKstYmd = (ymd, n) => {
   return toKstYmd(shifted);
 };
 
-module.exports = { toKstYmd, addDaysFromKstYmd };
+module.exports = {
+  toKstYmd,
+  kstDateKeyMinusDays,
+  kstDateKey,
+  addDaysFromKstYmd,
+};


### PR DESCRIPTION
## 개요

 KST 날짜 유틸 함수 정리

## 변경 사항

- [x]  새로운 기능 추가
- [x]  버그 수정
- [ ]  리팩토링
- [ ]  문서 수정

## 구현 내용

- **`kst-utils.js` : KST 날짜 유틸 함수 추가 및 정리 (순수 JS 기반)**
    - `kstDateKeyMinusDays` : today 기준 N일 전(KST) → "YYYY-MM-DD" 변환 함수 추가
    - `kstDateKey` : 임의 날짜 → KST "YYYY-MM-DD" 변환 함수 추가
    - `addDaysFromKstYmd` 리팩터링
    - 외부 라이브러리에 의존하지 않고 **순수 JS(Date API)** 로만 구현
- **`diary.controller.js` : diary 응답에 dateKey/date 필드 추가 및 KST 유틸 교체**
    - `utils/kst-utils`(순수 JS Date 기반 함수) 사용하도록 변경
    - diary 응답 객체에 `dateKey`, `date` 필드 추가
    → 클라이언트가 KST 기준 문자열 키와 원본 Date 모두 활용 가능

## 개발 후기 및 개선사항

### 이번 작업에서 배운 점

- (없다면 패스)

### 어려웠던 점 / 에로사항

- (없다면 패스)

### 다음에 개선하고 싶은 점

- (없다면 패스)

### 팀원들과 공유하고 싶은 팁

- (없다면 패스)