### PR TITLE
fix: 중복 저장 시 상태 분리

### DIFF
--- a/models/Vocabook.js
+++ b/models/Vocabook.js
@@ -8,7 +8,6 @@ const vocabookSchema = new Schema(
     meaning: { type: String }, // OpenAI에서 받아온 뜻
     example: { type: String }, // OpenAI에서 받아온 예문
     status: { type: String, default: "learning" }, //단어 상태
-    isDeleted: { type: Boolean, default: false }, //삭제
   },
   {
     timestamps: true, // createdAt, updatedAt 자동 관리


### PR DESCRIPTION
## 개요

중복 저장 시 상태 분리하였습니다.

## 변경 사항

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정

## 구현 내용

`if (error.code === 11000) {
      return res.status(409).json({
        status: "fail",
        message: "이미 단어장에 추가된 단어입니다.",
      });
    }`

- duplication 에러 코드인 11000 을 이용해 중복 시 상태를 관리하였습니다.

## 개발 후기 및 개선사항

### 이번 작업에서 배운 점

- (없다면 패스)

### 어려웠던 점 / 에로사항

- (없다면 패스)

### 다음에 개선하고 싶은 점

- (없다면 패스)

### 팀원들과 공유하고 싶은 팁

- (없다면 패스)
